### PR TITLE
Adding StandardActionConvertible back from ReSwift

### DIFF
--- a/ReactiveReSwift.xcodeproj/project.pbxproj
+++ b/ReactiveReSwift.xcodeproj/project.pbxproj
@@ -79,6 +79,13 @@
 		9E1F6FBA1DEE810400912955 /* Middleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E1F6FB81DEE810400912955 /* Middleware.swift */; };
 		9E1F6FBB1DEE810400912955 /* Middleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E1F6FB81DEE810400912955 /* Middleware.swift */; };
 		9E1F6FBC1DEE810400912955 /* Middleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E1F6FB81DEE810400912955 /* Middleware.swift */; };
+		FC03AA1B1E26BF330034FBFA /* StandardActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC03AA1A1E26BF330034FBFA /* StandardActionTests.swift */; };
+		FC03AA1C1E26BF330034FBFA /* StandardActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC03AA1A1E26BF330034FBFA /* StandardActionTests.swift */; };
+		FC03AA1D1E26BF330034FBFA /* StandardActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC03AA1A1E26BF330034FBFA /* StandardActionTests.swift */; };
+		FC15F3FB1E21C72100CF4886 /* Coding.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC15F3FA1E21C72100CF4886 /* Coding.swift */; };
+		FC15F3FC1E21C72100CF4886 /* Coding.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC15F3FA1E21C72100CF4886 /* Coding.swift */; };
+		FC15F3FD1E21C72100CF4886 /* Coding.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC15F3FA1E21C72100CF4886 /* Coding.swift */; };
+		FC15F3FE1E21C72100CF4886 /* Coding.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC15F3FA1E21C72100CF4886 /* Coding.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -134,6 +141,8 @@
 		9E1F6F9A1DED120A00912955 /* ObservablePropertyType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObservablePropertyType.swift; sourceTree = "<group>"; };
 		9E1F6F9B1DED120A00912955 /* StreamType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StreamType.swift; sourceTree = "<group>"; };
 		9E1F6FB81DEE810400912955 /* Middleware.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Middleware.swift; sourceTree = "<group>"; };
+		FC03AA1A1E26BF330034FBFA /* StandardActionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StandardActionTests.swift; sourceTree = "<group>"; };
+		FC15F3FA1E21C72100CF4886 /* Coding.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Coding.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -220,6 +229,7 @@
 			children = (
 				625E66861C1FF97E0027C288 /* ReactiveReSwift.h */,
 				625E66881C1FF97E0027C288 /* Info.plist */,
+				FC15F3F91E21C6C500CF4886 /* Utils */,
 				625E66B51C1FFC880027C288 /* CoreTypes */,
 				9E1F6F7E1DED0C4D00912955 /* Reactive */,
 			);
@@ -237,6 +247,7 @@
 				9E1F6F401DE7D15200912955 /* StoreMiddlewareTests.swift */,
 				9E1F6F411DE7D15200912955 /* StoreTests.swift */,
 				259737FA1C2C618A00869B8F /* TestFakes.swift */,
+				FC03AA1A1E26BF330034FBFA /* StandardActionTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -264,6 +275,14 @@
 				9E1F6F7F1DED0CB000912955 /* SubscriptionReferenceType.swift */,
 			);
 			path = Reactive;
+			sourceTree = "<group>";
+		};
+		FC15F3F91E21C6C500CF4886 /* Utils */ = {
+			isa = PBXGroup;
+			children = (
+				FC15F3FA1E21C72100CF4886 /* Coding.swift */,
+			);
+			path = Utils;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -589,6 +608,7 @@
 				9E1F6FA31DED120A00912955 /* StreamType.swift in Sources */,
 				9E1F6F8D1DED0D1100912955 /* ObservablePropertySubscriptionReference.swift in Sources */,
 				9E1F6F881DED0CEA00912955 /* ObservableProperty.swift in Sources */,
+				FC15F3FE1E21C72100CF4886 /* Coding.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -607,6 +627,7 @@
 				9E1F6FA21DED120A00912955 /* StreamType.swift in Sources */,
 				9E1F6F8C1DED0D1100912955 /* ObservablePropertySubscriptionReference.swift in Sources */,
 				9E1F6F871DED0CEA00912955 /* ObservableProperty.swift in Sources */,
+				FC15F3FD1E21C72100CF4886 /* Coding.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -620,6 +641,7 @@
 				9E1F6F501DE7D15200912955 /* StoreTests.swift in Sources */,
 				25DBCF731C30C34000D63A58 /* ReducerTests.swift in Sources */,
 				9E1F6F591DE7D15200912955 /* ReactiveTests.swift in Sources */,
+				FC03AA1D1E26BF330034FBFA /* StandardActionTests.swift in Sources */,
 				25DBCF751C30C34000D63A58 /* TestFakes.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -639,6 +661,7 @@
 				9E1F6FA11DED120A00912955 /* StreamType.swift in Sources */,
 				9E1F6F8B1DED0D1100912955 /* ObservablePropertySubscriptionReference.swift in Sources */,
 				9E1F6F861DED0CEA00912955 /* ObservableProperty.swift in Sources */,
+				FC15F3FC1E21C72100CF4886 /* Coding.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -652,6 +675,7 @@
 				9E1F6F4F1DE7D15200912955 /* StoreTests.swift in Sources */,
 				25DBCF9E1C30C50000D63A58 /* ReducerTests.swift in Sources */,
 				9E1F6F581DE7D15200912955 /* ReactiveTests.swift in Sources */,
+				FC03AA1C1E26BF330034FBFA /* StandardActionTests.swift in Sources */,
 				25DBCFA01C30C50000D63A58 /* TestFakes.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -671,6 +695,7 @@
 				9E1F6F851DED0CEA00912955 /* ObservableProperty.swift in Sources */,
 				625E66BE1C1FFC880027C288 /* Reducer.swift in Sources */,
 				625E66BF1C1FFC880027C288 /* State.swift in Sources */,
+				FC15F3FB1E21C72100CF4886 /* Coding.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -684,6 +709,7 @@
 				9E1F6F481DE7D15200912955 /* StoreDispatchTests.swift in Sources */,
 				9E1F6F4E1DE7D15200912955 /* StoreTests.swift in Sources */,
 				9E1F6F571DE7D15200912955 /* ReactiveTests.swift in Sources */,
+				FC03AA1B1E26BF330034FBFA /* StandardActionTests.swift in Sources */,
 				621C06861C277759008029AE /* ReducerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Sources/CoreTypes/Action.swift
+++ b/Sources/CoreTypes/Action.swift
@@ -1,12 +1,120 @@
 //
 //  Action.swift
-//  ReactiveReSwift
+//  ReSwift
 //
 //  Created by Benjamin Encz on 12/14/15.
 //  Copyright © 2015 Benjamin Encz. All rights reserved.
 //
 
 import Foundation
+/**
+ This is ReSwift's built in action type, it is the only built in type that conforms to the
+ `Action` protocol. `StandardAction` can be serialized and can therefore be used with developer
+ tools that restore state between app launches.
+ 
+ The downside of `StandardAction` is that it carries its payload as an untyped dictionary which does
+ not play well with Swift's type system.
+ 
+ It is recommended that you define your own types that conform to `Action` - if you want to be able
+ to serialize your custom action types, you can implement `StandardActionConvertible` which will
+ make it possible to generate a `StandardAction` from your typed action - the best of both worlds!
+ */
+public struct StandardAction: Action {
+    /// A String that identifies the type of this `StandardAction`
+    public let type: String
+    /// An untyped, JSON-compatible payload
+    public let payload: [String: AnyObject]?
+    /// Indicates whether this action will be deserialized as a typed action or as a standard action
+    public let isTypedAction: Bool
+    
+    /**
+     Initializes this `StandardAction` with a type, a payload and information about whether this is
+     a typed action or not.
+     
+     - parameter type:          String representation of the Action type
+     - parameter payload:       Payload convertable to JSON
+     - parameter isTypedAction: Is Action a subclassed type
+     */
+    public init(type: String, payload: [String: AnyObject]? = nil, isTypedAction: Bool = false) {
+        self.type = type
+        self.payload = payload
+        self.isTypedAction = isTypedAction
+    }
+}
+
+// MARK: Coding Extension
+
+private let typeKey = "type"
+private let payloadKey = "payload"
+private let isTypedActionKey = "isTypedAction"
+let reSwiftNull = "ReSwift_Null"
+
+extension StandardAction: Coding {
+    
+    public init?(dictionary: [String: AnyObject]) {
+        guard let type = dictionary[typeKey] as? String,
+            let isTypedAction = dictionary[isTypedActionKey] as? Bool else { return nil }
+        self.type = type
+        self.payload = dictionary[payloadKey] as? [String: AnyObject]
+        self.isTypedAction = isTypedAction
+    }
+    
+    public var dictionaryRepresentation: [String: AnyObject] {
+        let payload: AnyObject = self.payload as AnyObject? ?? reSwiftNull as AnyObject
+        
+        return [typeKey: type as NSString,
+                payloadKey: payload,
+                isTypedActionKey: isTypedAction as NSNumber]
+    }
+}
+
+/// Implement this protocol on your custom `Action` type if you want to make the action
+/// serializable.
+/// - Note: We are working on a tool to automatically generate the implementation of this protocol
+///     for your custom action types.
+public protocol StandardActionConvertible: Action {
+    /**
+     Within this initializer you need to use the payload from the `StandardAction` to configure the
+     state of your custom action type.
+     
+     Example:
+     
+     ```
+     init(_ standardAction: StandardAction) {
+     self.twitterUser = decode(standardAction.payload!["twitterUser"]!)
+     }
+     ```
+     
+     - Note: If you, as most developers, only use action serialization/deserialization during
+     development, you can feel free to use the unsafe `!` operator.
+     */
+    init (_ standardAction: StandardAction)
+    
+    /**
+     Use the information from your custom action to generate a `StandardAction`. The `type` of the
+     StandardAction should typically match the type name of your custom action type. You also need
+     to set `isTypedAction` to `true`. Use the information from your action's properties to
+     configure the payload of the `StandardAction`.
+     
+     Example:
+     
+     ```
+     func toStandardAction() -> StandardAction {
+     let payload = ["twitterUser": encode(self.twitterUser)]
+     
+     return StandardAction(type: SearchTwitterScene.SetSelectedTwitterUser.type,
+     payload: payload, isTypedAction: true)
+     }
+     ```
+     
+     */
+    func toStandardAction() -> StandardAction
+}
 
 /// All actions that want to be able to be dispatched to a store need to conform to this protocol
+/// Currently it is just a marker protocol with no requirements.
 public protocol Action { }
+
+/// Initial Action that is dispatched as soon as the store is created.
+/// Reducers respond to this action by configuring their intial state.
+public struct ReSwiftInit: Action {}

--- a/Sources/Utils/Coding.swift
+++ b/Sources/Utils/Coding.swift
@@ -1,0 +1,14 @@
+//
+//  Types.swift
+//  ReSwift
+//
+//  Created by Benjamin Encz on 11/27/15.
+//  Copyright © 2015 DigiTales. All rights reserved.
+//
+
+import Foundation
+
+public protocol Coding {
+    init?(dictionary: [String: AnyObject])
+    var dictionaryRepresentation: [String: AnyObject] { get }
+}

--- a/Tests/StandardActionTests.swift
+++ b/Tests/StandardActionTests.swift
@@ -5,6 +5,7 @@
 //  Created by Benjamin Encz on 12/29/15.
 //  Copyright © 2015 Benjamin Encz. All rights reserved.
 //
+
 import XCTest
 import ReactiveReSwift
 
@@ -137,5 +138,52 @@ class StandardActionInitSerializationTests: XCTestCase {
         let deserializedAction = StandardAction(dictionary: [:])
 
         XCTAssertNil(deserializedAction)
+    }
+}
+
+class StandardActionConvertibleInit: XCTestCase {
+
+    /**
+     it initializer returns nil when invalid dictionary is passed in
+     */
+    func testInitWithStandardAction() {
+        let standardAction = StandardAction(type: "Test", payload: ["value": 10 as AnyObject])
+        let action = SetValueAction(standardAction)
+
+        XCTAssertEqual(action.value, 10)
+    }
+
+    func testInitWithStringStandardAction() {
+        let standardAction = StandardAction(type: "Test", payload: ["value": "10" as AnyObject])
+        let action = SetValueStringAction(standardAction)
+
+        XCTAssertEqual(action.value, "10")
+    }
+
+}
+
+class StandardActionConvertibleTests: XCTestCase {
+
+    /**
+     it can be converted to a standard action
+     */
+    func testConvertToStandardAction() {
+        let action = SetValueAction(5)
+
+        let standardAction = action.toStandardAction()
+
+        XCTAssertEqual(standardAction.type, "SetValueAction")
+        XCTAssertEqual(standardAction.isTypedAction, true)
+        XCTAssertEqual(standardAction.payload?["value"] as? Int, 5)
+    }
+
+    func testConvertToStringStandardAction() {
+        let action = SetValueStringAction("5")
+
+        let standardAction = action.toStandardAction()
+
+        XCTAssertEqual(standardAction.type, "SetValueStringAction")
+        XCTAssertEqual(standardAction.isTypedAction, true)
+        XCTAssertEqual(standardAction.payload?["value"] as? String, "5")
     }
 }

--- a/Tests/StandardActionTests.swift
+++ b/Tests/StandardActionTests.swift
@@ -1,0 +1,141 @@
+//
+//  StandardActionTests.swift
+//  ReSwift
+//
+//  Created by Benjamin Encz on 12/29/15.
+//  Copyright © 2015 Benjamin Encz. All rights reserved.
+//
+import XCTest
+import ReactiveReSwift
+
+class StandardActionInitTests: XCTestCase {
+
+    /**
+     it can be initialized with just a type
+     */
+    func testInitWithType() {
+        let action = StandardAction(type: "Test")
+
+        XCTAssertEqual(action.type, "Test")
+    }
+
+    /**
+     it can be initialized with a type and a payload
+     */
+    func testInitWithTypeAndPayload() {
+        let action = StandardAction(type:"Test", payload: ["testKey": 5 as AnyObject])
+
+        let payload = action.payload!["testKey"]! as! Int
+
+        XCTAssertEqual(payload, 5)
+        XCTAssertEqual(action.type, "Test")
+    }
+
+}
+
+class StandardActionInitSerializationTests: XCTestCase {
+
+    /**
+     it can initialize action with a dictionary
+     */
+    func testCanInitWithDictionary() {
+        let actionDictionary: [String: AnyObject] = [
+            "type": "TestType" as AnyObject,
+            "payload": "ReSwift_Null" as AnyObject,
+            "isTypedAction": true as AnyObject
+        ]
+
+        let action = StandardAction(dictionary: actionDictionary)
+
+        XCTAssertEqual(action?.type, "TestType")
+        XCTAssertNil(action?.payload)
+        XCTAssertEqual(action?.isTypedAction, true)
+    }
+
+    /**
+     it can convert an action to a dictionary
+     */
+    func testConvertActionToDict() {
+        let action = StandardAction(type:"Test", payload: ["testKey": 5 as AnyObject],
+                                    isTypedAction: true)
+
+        let dictionary = action.dictionaryRepresentation
+
+        let type = dictionary["type"] as! String
+        let payload = dictionary["payload"] as! [String: AnyObject]
+        let isTypedAction = dictionary["isTypedAction"] as! Bool
+
+        XCTAssertEqual(type, "Test")
+        XCTAssertEqual(payload["testKey"] as? Int, 5)
+        XCTAssertEqual(isTypedAction, true)
+    }
+
+    /**
+     it can serialize / deserialize actions with payload and without custom type
+     */
+    func testWithPayloadWithoutCustomType() {
+        let action = StandardAction(type:"Test", payload: ["testKey": 5 as AnyObject])
+        let dictionary = action.dictionaryRepresentation
+
+        let deserializedAction = StandardAction(dictionary: dictionary)
+
+        let payload = deserializedAction?.payload?["testKey"] as? Int
+
+        XCTAssertEqual(payload, 5)
+        XCTAssertEqual(deserializedAction?.type, "Test")
+    }
+
+    /**
+     it can serialize / deserialize actions with payload and with custom type
+     */
+    func testWithPayloadAndCustomType() {
+        let action = StandardAction(type:"Test", payload: ["testKey": 5 as AnyObject],
+                                    isTypedAction: true)
+        let dictionary = action.dictionaryRepresentation
+
+        let deserializedAction = StandardAction(dictionary: dictionary)
+
+        let payload = deserializedAction?.payload?["testKey"] as? Int
+
+        XCTAssertEqual(payload, 5)
+        XCTAssertEqual(deserializedAction?.type, "Test")
+        XCTAssertEqual(deserializedAction?.isTypedAction, true)
+    }
+
+    /**
+     it can serialize / deserialize actions without payload and without custom type
+     */
+    func testWithoutPayloadOrCustomType() {
+        let action = StandardAction(type:"Test", payload: nil)
+        let dictionary = action.dictionaryRepresentation
+
+        let deserializedAction = StandardAction(dictionary: dictionary)
+
+        XCTAssertNil(deserializedAction?.payload)
+        XCTAssertEqual(deserializedAction?.type, "Test")
+    }
+
+    /**
+     it can serialize / deserialize actions without payload and with custom type
+     */
+    func testWithoutPayloadWithCustomType() {
+        let action = StandardAction(type:"Test", payload: nil,
+                                    isTypedAction: true)
+        let dictionary = action.dictionaryRepresentation
+
+        let deserializedAction = StandardAction(dictionary: dictionary)
+
+        XCTAssertNil(deserializedAction?.payload)
+        XCTAssertEqual(deserializedAction?.type, "Test")
+        XCTAssertEqual(deserializedAction?.isTypedAction, true)
+    }
+
+    /**
+     it initializer returns nil when invalid dictionary is passed in
+     */
+    func testReturnsNilWhenInvalid() {
+        let deserializedAction = StandardAction(dictionary: [:])
+
+        XCTAssertNil(deserializedAction)
+    }
+}

--- a/Tests/TestFakes.swift
+++ b/Tests/TestFakes.swift
@@ -25,22 +25,44 @@ struct TestStringAppState: StateType {
     var testValue: String?
 }
 
-struct SetValueAction: Action {
+struct SetValueAction: StandardActionConvertible {
 
     let value: Int
+    static let type = "SetValueAction"
 
     init (_ value: Int) {
         self.value = value
     }
 
+    init(_ standardAction: StandardAction) {
+        self.value = standardAction.payload!["value"] as! Int
+    }
+
+    func toStandardAction() -> StandardAction {
+        return StandardAction(type: SetValueAction.type,
+                              payload: ["value": value as AnyObject],
+                              isTypedAction: true)
+    }
+
 }
 
-struct SetValueStringAction: Action {
+struct SetValueStringAction: StandardActionConvertible {
 
     var value: String
+    static let type = "SetValueStringAction"
 
     init (_ value: String) {
         self.value = value
+    }
+
+    init(_ standardAction: StandardAction) {
+        self.value = standardAction.payload!["value"] as! String
+    }
+
+    func toStandardAction() -> StandardAction {
+        return StandardAction(type: SetValueStringAction.type,
+                              payload: ["value": value as AnyObject],
+                              isTypedAction: true)
     }
 
 }


### PR DESCRIPTION
First off, thanks for your work on this library! I may become active in this space as I try to incorporate these concepts into a new project I am working on.

This enables serialization for actions and better compatibility with other ReSwift-* libraries.

Specifically, I am trying to create ReactiveReSwift-Router that depends on ReactiveReSwift. This commit gets the other project compiling. More commits may be on the way. Was there any particular reason you removed or didn't re-implement this stuff?