### PR TITLE
Fix issue in podspec github url.

### DIFF
--- a/ReactiveReSwift.podspec
+++ b/ReactiveReSwift.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
     "Charlotte Tortorella" => "charlotte@monadic.consulting"
   }
   s.source            = {
-    :git => "https://github.com/ReSwift/ReactiveReSwift",
+    :git => "https://github.com/ReSwift/ReactiveReSwift.git",
     :tag => s.version.to_s
   }
 


### PR DESCRIPTION
Fixed lint warning "WARN  | github_sources: Github repositories should end in `.git`.", added `.git`.