### PR TITLE
allow dispatching actions as an array, without removing ability to dispatch with list of actions as arguments

### DIFF
--- a/Sources/CoreTypes/Store.swift
+++ b/Sources/CoreTypes/Store.swift
@@ -25,7 +25,7 @@ open class Store<ObservableProperty: ObservablePropertyType> {
         self.middleware = middleware
     }
 
-    open func dispatch(_ actions: Action...) {
+    open func dispatch(_ actions: [Action]) {
         actions.forEach { action in
             let dispatchFunction: (Action...) -> Void = { [weak self] (actions: Action...) in
                 actions.forEach { self?.dispatch($0) }
@@ -34,6 +34,10 @@ open class Store<ObservableProperty: ObservablePropertyType> {
                 observable.value = reducer(action, observable.value)
             }
         }
+    }
+
+    open func dispatch(_ actions: Action...) {
+        self.dispatch(actions)
     }
 
     @discardableResult


### PR DESCRIPTION
In my app, I needed to be able to dispatch an array of actions. Array's cannot currently be converted into lists of arguments in the Swift language. So we must refactor the code to work the other way:
- the core logic lives inside the function that accepts an array of arguments. The function that takes the variadic list of actions then calls the array implementation. 